### PR TITLE
Update CVAE documentation and conditioning variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Conditional Variational Autoencoder for Topographic Profiles
+# Conditional Variational Autoencoder for Reconstructing Topographic Profiles
 
 This repository contains a minimal implementation of the Conditional Variational
-Autoencoder (CVAE) used to reconstruct the Quaternary Normal Plateau (QNP)
-profiles described in the accompanying paper.  The code was originally written
+Autoencoder (CVAE) used to reconstruct the **Quaternary Nazca Peneplain (QNP)**
+profiles described in the unpublished paper *"Quaternary tectonic shortening and
+uplift of the Peruvian forearc due to subduction of the Nazca Ridge: a
+quantitative approach"* by Luis Ayala-Carazas, Willem Viveen*, Patrice Baby,
+Rodrigo Uribe-Ventura, Steven Binnie, Jorge Sanjurjo-Sánchez and
+César Beltrán-Castallon.  The code was originally written
 in a large notebook but has been refactored into a small, easy to review
 package.
 
@@ -29,10 +33,11 @@ the trained model will be saved under `models/cvae_model`.
 
 3. Generate new profiles from a trained model:
    ```bash
-   python generate.py models/cvae_model 1.0 -1.0 -n 5
+   python generate.py models/cvae_model 0.0 0.1 -n 5
    ```
 
 The architecture follows the specifications in the paper with dense layers of
 512 and 256 units in the encoder, a 200‑dimensional latent space and symmetric
-decoder.  Conditioning on the start and end elevation of each profile allows the
-model to estimate missing QNP segments along the cross sections.
+decoder.  Conditioning on the **elevation point** and **terrain gradient** at
+each profile location allows the model to estimate missing QNP segments along
+the cross sections.

--- a/cvae/dataset.py
+++ b/cvae/dataset.py
@@ -74,13 +74,22 @@ def create_dataset(
     save_dir: str,
     source: str = "synthetic",
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Generate ``num_samples`` profiles of the given ``source`` and save them."""
+    """Generate ``num_samples`` profiles of the given ``source`` and save them.
+
+    Each sample is represented by a pair of conditioning variables: the
+    elevation point at the start of the profile and the terrain gradient
+    calculated from the first and last points.
+    """
     os.makedirs(save_dir, exist_ok=True)
 
     X, Y = [], []
     for _ in range(num_samples):
         profile = generate_profile(source=source)
-        X.append([profile[0, 1], profile[-1, 1]])
+        elevation_point = profile[0, 1]
+        terrain_gradient = (
+            profile[-1, 1] - profile[0, 1]
+        ) / (profile[-1, 0] - profile[0, 0])
+        X.append([elevation_point, terrain_gradient])
         Y.append(profile[:, 1])
 
     X_arr = np.array(X)

--- a/generate.py
+++ b/generate.py
@@ -15,16 +15,15 @@ def simple_moving_average(data: np.ndarray, window_size: int = 5) -> np.ndarray:
     return ma
 
 
-def generate(model_path: str, start: float, end: float, num: int = 1) -> np.ndarray:
+def generate(model_path: str, elevation_point: float, terrain_gradient: float, num: int = 1) -> np.ndarray:
     model = load_model(model_path)
     decoder = model.decoder
     profiles = []
-    condition = np.array([[start, end]])
+    condition = np.array([[elevation_point, terrain_gradient]])
     for _ in range(num):
         z = np.random.normal(size=(1, LATENT_DIM))
         profile = decoder.predict([z, condition], verbose=0)[0]
-        profile[0] = start
-        profile[-1] = end
+        profile[0] = elevation_point
         profile = simple_moving_average(profile)
         profiles.append(profile)
     return np.array(profiles)
@@ -33,12 +32,12 @@ def generate(model_path: str, start: float, end: float, num: int = 1) -> np.ndar
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate profiles using a trained CVAE model")
     parser.add_argument("model", help="Path to saved model")
-    parser.add_argument("start", type=float, help="Start elevation")
-    parser.add_argument("end", type=float, help="End elevation")
+    parser.add_argument("elevation_point", type=float, help="Elevation point")
+    parser.add_argument("terrain_gradient", type=float, help="Terrain gradient")
     parser.add_argument("-n", "--num", type=int, default=1, help="Number of profiles")
     args = parser.parse_args()
 
-    profiles = generate(args.model, args.start, args.end, args.num)
+    profiles = generate(args.model, args.elevation_point, args.terrain_gradient, args.num)
     np.set_printoptions(precision=3, suppress=True)
     print(profiles)
 


### PR DESCRIPTION
## Summary
- clarify that the model is a **Conditional Variational Autoencoder for Reconstructing Topographic Profiles**
- update README to describe usage for the Quaternary Nazca Peneplain (QNP)
- use *elevation point* and *terrain gradient* as conditioning variables
- adjust dataset generation and profile generator accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685566cc8f488332b602e7a3c33bc10c